### PR TITLE
Refactoring to do batch lookups instead of single lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ README.html
 
 # Ignored installed NPM modules
 node_modules/
+
+.polarity.conf

--- a/config/config.js
+++ b/config/config.js
@@ -1,7 +1,7 @@
 module.exports = {
     name: 'ReversingLabs A1000',
     acronym: 'A1000',
-    logging: {level: 'trace'},
+    logging: { level: 'trace' },
     entityTypes: ['hash'],
     description: 'ReversingLabs A1000 integration for real-time file hash lookups',
     styles: [
@@ -16,7 +16,7 @@ module.exports = {
             file: './template/block.hbs'
         }
     },
-  
+
     request: {
         // Provide the path to your certFile. Leave an empty string to ignore this option.
         // Relative paths are relative to the VT integration's root directory

--- a/package.json
+++ b/package.json
@@ -8,5 +8,13 @@
     "request": "2.83.0",
     "async": "2.5.0",
     "lodash": "4.17.4"
+  },
+  "scripts": {
+    "dev": "./sync.js"
+  },
+  "devDependencies": {
+    "node-ssh": "^5.1.1",
+    "node-watch": "^0.5.8",
+    "scp2": "^0.5.0"
   }
 }

--- a/sync.js
+++ b/sync.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+let watch = require('node-watch');
+let client = require('scp2');
+let NodeSsh = require('node-ssh');
+let Path = require('path');
+let readline = require('readline');
+let fs = require('fs');
+
+let config = {};
+if (fs.existsSync('./.polarity.conf')) {
+    config = require('./.polarity.conf');
+}
+
+let ssh = new NodeSsh();
+let reader = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+if (config.username && config.password) {
+    startSync(config.username, config.password);
+} else {
+    reader.question('Polarity server username > ', (USERNAME) => {
+        reader.question('Polarity server password > ', (PASSWORD) => {
+            startSync(USERNAME, PASSWORD);
+        });
+    });
+}
+
+function startSync(USERNAME, PASSWORD) {
+    console.log('Watch sever started');
+    watch('.', { recursive: true }, (eventType, filename) => {
+        if (filename.indexOf('.git') !== -1) {
+            return;
+        }
+
+        console.log('Change detected: ' + filename);
+
+        client.scp(filename, {
+            username: config.username ? config.username : USERNAME,
+            password: config.password ? config.password : PASSWORD,
+            host: config.host ? config.host : 'dev.polarity',
+            path: '/app/polarity-server/integrations/reversinglabs-A1000/' + Path.dirname(filename)
+        }, (err) => {
+            if (err) {
+                console.error('Failed to sync change for ' + filename + ', error was: ' + err);
+                return;
+            }
+
+            ssh.connect({
+                host: 'dev.polarity',
+                username: USERNAME,
+                password: PASSWORD
+            })
+                .then(() => {
+                    return ssh.exec('service polarityd restart');
+                })
+                .catch((err) => {
+                    if (err && err.message === 'Redirecting to /bin/systemctl restart polarityd.service') {
+                        return;
+                    }
+
+                    throw err;
+                })
+                .then(() => {
+                    console.log('Change synced: ' + filename);
+                })
+                .catch((err) => {
+                    if (err) {
+                        console.error('Failed to restart polarity server, error was: ' + err);
+                    }
+                });
+        });
+    });
+}

--- a/template/block.hbs
+++ b/template/block.hbs
@@ -1,6 +1,6 @@
 <div class="p-non-exfoliate-outer-padding">
-  {{#if details.results}}
-  {{#each details.results as |result| }}
+  {{#if details}}
+  {{#each details as |result| }}
 
   {{#if result.threat_level}}
     <div>


### PR DESCRIPTION
Refactoring the Reversing Labs integration to do batch lookups instead of single hash lookups.  Lookups are bucketed into SHA1, SHA256, and MD5 groups because reversing labs doesn't support mixed type lookups.